### PR TITLE
:bug: Remove __platform__ from .yml file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
     with:
       compiler_profile_url: https://github.com/libhal/arm-gnu-toolchain.git
       compiler_profile: v1/arm-gcc-12.3
-      platform_profile_url: https://github.com/libhal/libhal-__platform__.git
-      platform_profile: profile1
+      # TODO: Update this with the correct information
+      # platform_profile_url: https://github.com/libhal/libhal-<insert repo name>.git
+      # platform_profile: profile1
     secrets: inherit


### PR DESCRIPTION
This causes issues with github actions so now it is a TODO. Github actions require advanced permissions to allow workflows to be modified by a workflow.